### PR TITLE
Add role-based access control for GitHub webhook requests

### DIFF
--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -26,20 +26,83 @@ webhook.post('/', async (c) => {
 
     logger.info('Received webhook', { eventType, action: payload.action });
 
+    // Check if this is an approval command
+    if (payload.comment?.body && githubService.isApprovalCommand(payload.comment.body)) {
+      const result = await handleApprovalCommand(eventType, payload);
+      return c.json(result);
+    }
+
     // Extract Claude instruction
     const instruction = await extractInstruction(eventType, payload);
 
     if (instruction) {
-      // Spawn agent asynchronously
-      claudeService.spawnAgent(instruction).catch((error) => {
-        logger.error('Failed to spawn agent', { error, instruction });
-      });
+      // Check sender permissions
+      try {
+        const permissionCheck = await githubService.checkUserPermission(
+          instruction.repository,
+          instruction.sender
+        );
 
-      return c.json({
-        status: 'agent_spawned',
-        type: instruction.type,
-        number: instruction.number,
-      });
+        if (!permissionCheck.isTrusted) {
+          // Unknown/untrusted sender - request manual review
+          logger.info('Request from untrusted sender requires review', {
+            sender: instruction.sender,
+            repository: instruction.repository,
+            permission: permissionCheck.permission,
+          });
+
+          // Post comment and add label
+          await Promise.all([
+            githubService.postComment(
+              instruction.repository,
+              instruction.number,
+              `@${instruction.sender} This request requires manual review because you don't have repository access.\n\n` +
+              `A maintainer with repository access can approve this by commenting:\n` +
+              `\`@claude approve\`\n\n` +
+              `**Security Notice:** This measure prevents consumption attacks and malicious prompt injection.`
+            ),
+            githubService.addPendingReviewLabel(
+              instruction.repository,
+              instruction.number
+            ),
+          ]);
+
+          return c.json({
+            status: 'pending_review',
+            type: instruction.type,
+            number: instruction.number,
+            sender: instruction.sender,
+            permission: permissionCheck.permission,
+          });
+        }
+
+        logger.info('Spawning agent for trusted sender', {
+          sender: instruction.sender,
+          repository: instruction.repository,
+          permission: permissionCheck.permission,
+          role: permissionCheck.role_name,
+        });
+
+        // Spawn agent asynchronously
+        claudeService.spawnAgent(instruction).catch((error) => {
+          logger.error('Failed to spawn agent', { error, instruction });
+        });
+
+        return c.json({
+          status: 'agent_spawned',
+          type: instruction.type,
+          number: instruction.number,
+          sender: instruction.sender,
+          permission: permissionCheck.permission,
+        });
+      } catch (error) {
+        logger.error('Permission check failed', { error, instruction });
+        // On error, fail safe: don't spawn agent
+        return c.json({
+          status: 'error',
+          error: 'Failed to verify user permissions',
+        }, 500);
+      }
     }
 
     return c.json({ status: 'ignored' });
@@ -48,6 +111,139 @@ webhook.post('/', async (c) => {
     return c.json({ error: 'Internal server error' }, 500);
   }
 });
+
+async function handleApprovalCommand(
+  eventType: string | undefined,
+  payload: GitHubWebhookPayload
+) {
+  // Only process approval commands from comments
+  if (eventType !== 'issue_comment' && eventType !== 'pull_request_review_comment') {
+    return { status: 'ignored' };
+  }
+
+  const number = payload.issue?.number || payload.pull_request?.number;
+  const type: 'issue' | 'pr' = payload.issue ? 'issue' : 'pr';
+  const approver = payload.sender.login;
+  const repository = payload.repository.full_name;
+
+  if (!number) {
+    return { status: 'ignored' };
+  }
+
+  try {
+    // Check if approver has permissions
+    const approverPermission = await githubService.checkUserPermission(
+      repository,
+      approver
+    );
+
+    if (!approverPermission.isTrusted) {
+      logger.warn('Approval attempt by untrusted user', {
+        approver,
+        repository,
+        number,
+        permission: approverPermission.permission,
+      });
+
+      await githubService.postComment(
+        repository,
+        number,
+        `@${approver} You don't have permission to approve this request. ` +
+        `Only users with repository access can approve.`
+      );
+
+      return {
+        status: 'approval_denied',
+        approver,
+        permission: approverPermission.permission,
+      };
+    }
+
+    // Get original issue/PR body to extract instruction
+    const originalBody = await githubService.getOriginalIssueBody(repository, number);
+
+    if (!originalBody) {
+      logger.warn('Could not retrieve original issue body for approval', {
+        repository,
+        number,
+      });
+
+      return { status: 'error', error: 'Could not retrieve original request' };
+    }
+
+    const instruction = githubService.extractClaudeMention(originalBody);
+
+    if (!instruction) {
+      logger.warn('No Claude instruction found in original issue', {
+        repository,
+        number,
+      });
+
+      await githubService.postComment(
+        repository,
+        number,
+        `No @claude instruction found in the original ${type}.`
+      );
+
+      return { status: 'no_instruction' };
+    }
+
+    // Extract original sender from issue/PR
+    const originalSender = type === 'issue'
+      ? payload.issue?.user.login
+      : payload.pull_request?.user.login;
+
+    if (!originalSender) {
+      return { status: 'error', error: 'Could not determine original sender' };
+    }
+
+    const claudeInstruction: ClaudeInstruction = {
+      type,
+      number,
+      instruction,
+      repository,
+      sender: originalSender,
+      cloneUrl: payload.repository.clone_url,
+    };
+
+    logger.info('Approval granted by trusted user', {
+      approver,
+      originalSender,
+      repository,
+      number,
+      approverPermission: approverPermission.permission,
+    });
+
+    // Remove pending review label and spawn agent
+    await Promise.all([
+      githubService.removePendingReviewLabel(repository, number),
+      githubService.postComment(
+        repository,
+        number,
+        `✅ Approved by @${approver} - spawning Claude agent...`
+      ),
+    ]);
+
+    claudeService.spawnAgent(claudeInstruction).catch((error) => {
+      logger.error('Failed to spawn agent after approval', { error, claudeInstruction });
+    });
+
+    return {
+      status: 'approved_and_spawned',
+      type,
+      number,
+      approver,
+      originalSender,
+      approverPermission: approverPermission.permission,
+    };
+  } catch (error) {
+    logger.error('Approval command handler error', { error, repository, number });
+    return {
+      status: 'error',
+      error: 'Failed to process approval',
+    };
+  }
+}
 
 async function extractInstruction(
   eventType: string | undefined,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,7 +1,75 @@
 import { spawn } from 'child_process';
 import logger from '../utils/logger';
 
+export type RepositoryPermission = 'admin' | 'write' | 'read' | 'none';
+
+export interface PermissionCheckResult {
+  permission: RepositoryPermission;
+  role_name: string;
+  isTrusted: boolean;
+}
+
 export class GitHubService {
+  async checkUserPermission(
+    repository: string,
+    username: string
+  ): Promise<PermissionCheckResult> {
+    return new Promise((resolve, reject) => {
+      const [owner, repo] = repository.split('/');
+      const proc = spawn('gh', [
+        'api',
+        `/repos/${owner}/${repo}/collaborators/${username}/permission`,
+      ]);
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          try {
+            const response = JSON.parse(stdout);
+            const permission = response.permission as RepositoryPermission;
+            const role_name = response.role_name || permission;
+
+            // Trusted users: admin, write (includes maintain), or read (includes triage)
+            // We exclude 'none' which means they have no explicit repository access
+            const isTrusted = permission !== 'none';
+
+            logger.info('Checked user permission', {
+              repository,
+              username,
+              permission,
+              role_name,
+              isTrusted
+            });
+
+            resolve({ permission, role_name, isTrusted });
+          } catch (error) {
+            logger.error('Failed to parse permission response', { error, stdout });
+            reject(new Error(`Failed to parse GitHub API response: ${error}`));
+          }
+        } else {
+          logger.warn('Permission check failed', { stderr, repository, username });
+          // If permission check fails (e.g., user not found), treat as untrusted
+          resolve({ permission: 'none', role_name: 'none', isTrusted: false });
+        }
+      });
+
+      proc.on('error', (error) => {
+        logger.error('Failed to spawn gh CLI for permission check', { error });
+        reject(error);
+      });
+    });
+  }
+
   async postComment(
     repository: string,
     issueNumber: number,
@@ -40,6 +108,45 @@ export class GitHubService {
     });
   }
 
+  async addPendingReviewLabel(
+    repository: string,
+    issueNumber: number
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const proc = spawn('gh', [
+        'issue',
+        'edit',
+        issueNumber.toString(),
+        '--repo',
+        repository,
+        '--add-label',
+        'claude-pending-review',
+      ]);
+
+      let stderr = '';
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          logger.info('Added pending review label', { repository, issueNumber });
+          resolve();
+        } else {
+          logger.error('Failed to add label', { stderr, repository, issueNumber });
+          // Don't reject - labeling is not critical
+          resolve();
+        }
+      });
+
+      proc.on('error', (error) => {
+        logger.error('Failed to spawn gh CLI for labeling', { error });
+        // Don't reject - labeling is not critical
+        resolve();
+      });
+    });
+  }
+
   extractClaudeMention(body: string): string | null {
     if (!body.toLowerCase().includes('@claude')) {
       return null;
@@ -66,6 +173,98 @@ export class GitHubService {
     }
 
     return instructionLines.length > 0 ? instructionLines.join('\n').trim() : null;
+  }
+
+  isApprovalCommand(body: string): boolean {
+    const claudePattern = /@claude\s+approve/i;
+    return claudePattern.test(body);
+  }
+
+  async removePendingReviewLabel(
+    repository: string,
+    issueNumber: number
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const proc = spawn('gh', [
+        'issue',
+        'edit',
+        issueNumber.toString(),
+        '--repo',
+        repository,
+        '--remove-label',
+        'claude-pending-review',
+      ]);
+
+      let stderr = '';
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          logger.info('Removed pending review label', { repository, issueNumber });
+          resolve();
+        } else {
+          logger.error('Failed to remove label', { stderr, repository, issueNumber });
+          // Don't reject - labeling is not critical
+          resolve();
+        }
+      });
+
+      proc.on('error', (error) => {
+        logger.error('Failed to spawn gh CLI for label removal', { error });
+        // Don't reject - labeling is not critical
+        resolve();
+      });
+    });
+  }
+
+  async getOriginalIssueBody(
+    repository: string,
+    issueNumber: number
+  ): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('gh', [
+        'issue',
+        'view',
+        issueNumber.toString(),
+        '--repo',
+        repository,
+        '--json',
+        'body',
+      ]);
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          try {
+            const response = JSON.parse(stdout);
+            resolve(response.body || null);
+          } catch (error) {
+            logger.error('Failed to parse issue body', { error, stdout });
+            reject(new Error(`Failed to parse GitHub API response: ${error}`));
+          }
+        } else {
+          logger.error('Failed to get issue body', { stderr, repository, issueNumber });
+          reject(new Error(`GitHub CLI failed: ${stderr}`));
+        }
+      });
+
+      proc.on('error', (error) => {
+        logger.error('Failed to spawn gh CLI for issue view', { error });
+        reject(error);
+      });
+    });
   }
 }
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -50,4 +50,36 @@ Thank you!
       expect(result).toBe('do something');
     });
   });
+
+  describe('isApprovalCommand', () => {
+    it('should detect @claude approve command', () => {
+      const body = '@claude approve';
+      const result = githubService.isApprovalCommand(body);
+      expect(result).toBe(true);
+    });
+
+    it('should detect case-insensitive approval', () => {
+      const body = '@CLAUDE APPROVE';
+      const result = githubService.isApprovalCommand(body);
+      expect(result).toBe(true);
+    });
+
+    it('should detect approval with extra spaces', () => {
+      const body = '@claude   approve';
+      const result = githubService.isApprovalCommand(body);
+      expect(result).toBe(true);
+    });
+
+    it('should not match other @claude commands', () => {
+      const body = '@claude do something else';
+      const result = githubService.isApprovalCommand(body);
+      expect(result).toBe(false);
+    });
+
+    it('should not match plain text', () => {
+      const body = 'I approve this';
+      const result = githubService.isApprovalCommand(body);
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { Hono } from 'hono';
 import webhook from '../src/routes/webhook';
+import githubService from '../src/services/github';
+import claudeService from '../src/services/claude';
 
 describe('Webhook Routes', () => {
   let app: Hono;
@@ -9,9 +11,18 @@ describe('Webhook Routes', () => {
     process.env.GITHUB_WEBHOOK_SECRET = 'test-secret';
     process.env.ANTHROPIC_API_KEY = 'test-key';
     process.env.GITHUB_TOKEN = 'test-token';
-    
+
     app = new Hono();
     app.route('/webhook', webhook);
+  });
+
+  beforeEach(() => {
+    // Mock spawnAgent to prevent actual agent spawning in tests
+    vi.spyOn(claudeService, 'spawnAgent').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   async function createSignature(payload: string): Promise<string> {
@@ -48,6 +59,9 @@ describe('Webhook Routes', () => {
       issue: {
         number: 1,
         body: '@claude test instruction',
+        user: {
+          login: 'testuser',
+        },
       },
       repository: {
         full_name: 'test/repo',
@@ -59,6 +73,13 @@ describe('Webhook Routes', () => {
     });
 
     const signature = await createSignature(payload);
+
+    // Mock permission check to return trusted user
+    vi.spyOn(githubService, 'checkUserPermission').mockResolvedValue({
+      permission: 'write',
+      role_name: 'write',
+      isTrusted: true,
+    });
 
     const res = await app.request('/webhook', {
       method: 'POST',
@@ -72,5 +93,191 @@ describe('Webhook Routes', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBeDefined();
+  });
+
+  it('should request review for untrusted sender', async () => {
+    const payload = JSON.stringify({
+      action: 'created',
+      issue: {
+        number: 2,
+        body: 'Original issue body',
+        user: {
+          login: 'issue-creator',
+        },
+      },
+      comment: {
+        body: '@claude malicious instruction',
+        user: {
+          login: 'unknown-user',
+        },
+      },
+      repository: {
+        full_name: 'test/repo',
+        clone_url: 'https://github.com/test/repo.git',
+      },
+      sender: {
+        login: 'unknown-user',
+      },
+    });
+
+    const signature = await createSignature(payload);
+
+    // Mock permission check to return untrusted user
+    vi.spyOn(githubService, 'checkUserPermission').mockResolvedValue({
+      permission: 'none',
+      role_name: 'none',
+      isTrusted: false,
+    });
+
+    // Mock comment and label methods
+    const postCommentSpy = vi.spyOn(githubService, 'postComment').mockResolvedValue();
+    const addLabelSpy = vi.spyOn(githubService, 'addPendingReviewLabel').mockResolvedValue();
+
+    const res = await app.request('/webhook', {
+      method: 'POST',
+      headers: {
+        'x-hub-signature-256': signature,
+        'x-github-event': 'issue_comment',
+      },
+      body: payload,
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('pending_review');
+    expect(json.sender).toBe('unknown-user');
+    expect(json.permission).toBe('none');
+
+    // Verify comment and label were added
+    expect(postCommentSpy).toHaveBeenCalledWith(
+      'test/repo',
+      2,
+      expect.stringContaining('requires manual review')
+    );
+    expect(addLabelSpy).toHaveBeenCalledWith('test/repo', 2);
+  });
+
+  it('should allow trusted user to approve pending request', async () => {
+    const payload = JSON.stringify({
+      action: 'created',
+      issue: {
+        number: 3,
+        body: 'Original issue body with @claude instruction',
+        user: {
+          login: 'original-user',
+        },
+      },
+      comment: {
+        body: '@claude approve',
+        user: {
+          login: 'maintainer',
+        },
+      },
+      repository: {
+        full_name: 'test/repo',
+        clone_url: 'https://github.com/test/repo.git',
+      },
+      sender: {
+        login: 'maintainer',
+      },
+    });
+
+    const signature = await createSignature(payload);
+
+    // Mock permission check for approver (trusted)
+    vi.spyOn(githubService, 'checkUserPermission').mockResolvedValue({
+      permission: 'admin',
+      role_name: 'admin',
+      isTrusted: true,
+    });
+
+    // Mock getting original issue body
+    vi.spyOn(githubService, 'getOriginalIssueBody').mockResolvedValue(
+      '@claude do something'
+    );
+
+    // Mock comment and label methods
+    const postCommentSpy = vi.spyOn(githubService, 'postComment').mockResolvedValue();
+    const removeLabelSpy = vi.spyOn(githubService, 'removePendingReviewLabel').mockResolvedValue();
+
+    const res = await app.request('/webhook', {
+      method: 'POST',
+      headers: {
+        'x-hub-signature-256': signature,
+        'x-github-event': 'issue_comment',
+      },
+      body: payload,
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('approved_and_spawned');
+    expect(json.approver).toBe('maintainer');
+
+    // Verify label was removed and approval comment posted
+    expect(removeLabelSpy).toHaveBeenCalledWith('test/repo', 3);
+    expect(postCommentSpy).toHaveBeenCalledWith(
+      'test/repo',
+      3,
+      expect.stringContaining('Approved by @maintainer')
+    );
+  });
+
+  it('should deny approval from untrusted user', async () => {
+    const payload = JSON.stringify({
+      action: 'created',
+      issue: {
+        number: 4,
+        body: 'Original issue',
+        user: {
+          login: 'original-user',
+        },
+      },
+      comment: {
+        body: '@claude approve',
+        user: {
+          login: 'untrusted-user',
+        },
+      },
+      repository: {
+        full_name: 'test/repo',
+        clone_url: 'https://github.com/test/repo.git',
+      },
+      sender: {
+        login: 'untrusted-user',
+      },
+    });
+
+    const signature = await createSignature(payload);
+
+    // Mock permission check for approver (untrusted)
+    vi.spyOn(githubService, 'checkUserPermission').mockResolvedValue({
+      permission: 'none',
+      role_name: 'none',
+      isTrusted: false,
+    });
+
+    const postCommentSpy = vi.spyOn(githubService, 'postComment').mockResolvedValue();
+
+    const res = await app.request('/webhook', {
+      method: 'POST',
+      headers: {
+        'x-hub-signature-256': signature,
+        'x-github-event': 'issue_comment',
+      },
+      body: payload,
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('approval_denied');
+    expect(json.approver).toBe('untrusted-user');
+
+    // Verify denial comment was posted
+    expect(postCommentSpy).toHaveBeenCalledWith(
+      'test/repo',
+      4,
+      expect.stringContaining("don't have permission to approve")
+    );
   });
 });


### PR DESCRIPTION
Implement security measures to prevent consumption attacks and prompt injection by validating sender permissions before spawning Claude agents.

**Features:**
- Check repository permissions via GitHub API before agent spawn
- Trusted users (read/write/admin access) bypass review
- Untrusted users require maintainer approval via `@claude approve`
- Auto-label pending requests with `claude-pending-review`
- Comprehensive test coverage for all workflows

**Security improvements:**
- Prevents consumption attacks from unknown users
- Blocks malicious prompt injection attempts
- Fail-safe: permission check errors prevent agent spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)